### PR TITLE
feat: (#1) Add CSV response to comments_controller

### DIFF
--- a/app/controllers/comments_controller.py
+++ b/app/controllers/comments_controller.py
@@ -1,16 +1,48 @@
 from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+import io
+import csv
+
 from app.domain.use_cases.comments_use_case import get_comments_for_user
 
 router = APIRouter()
 
 
 @router.get("/")
-def get_comments(login: str = Query(...)):
+def get_comments(login: str = Query(...), format: str = Query("json")):
     """
-    Эндпоинт для получения датасета comments по логину пользователя
-    Пример: GET /api/comments?login=john
+    Эндпоинт для получения датасета comments по логину пользователя, с выбором формата выдачи JSON/CSV
+    \nПример:
+        - GET /api/comments?login=john | Если не указать формат то выдаст JSON
+        - GET api/comments?login=john&format=csv | С указанием формата JSON/CSV
     """
     data = get_comments_for_user(login)
+
+    if format.lower() == "csv":
+        # Генерируем CSV как строку
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["user_login", "post_header", "post_author_login", "total_comments"])
+        for row in data:
+            writer.writerow([
+                row["user_login"],
+                row["post_header"],
+                row["post_author_login"],
+                row["total_comments"],
+            ])
+        csv_content = output.getvalue()
+        output.close()
+
+        # Создаем StreamingResponse
+        response = StreamingResponse(
+            iter([csv_content]),
+            media_type="text/csv"
+        )
+        # Заставляем браузер (или другой клиент) скачивать файл как "comments.csv"
+        response.headers["Content-Disposition"] = "attachment; filename=comments.csv"
+        return response
+
+    # По умолчанию JSON
     return {
         "status": "ok",
         "data": data

--- a/app/controllers/general_controller.py
+++ b/app/controllers/general_controller.py
@@ -1,17 +1,45 @@
 from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+import io
+import csv
 from app.domain.use_cases.general_use_case import get_general_for_user
 
 router = APIRouter()
 
 
 @router.get("/")
-def get_general(login: str = Query(...)):
+def get_general(login: str = Query(...), format: str = Query("json")):
     """
-    Эндпоинт для получения общего датасета general по логину пользователя
-    Пример: GET /api/general?login=john
+    Эндпоинт для получения общего датасета general по логину пользователя, с выбором формата выдачи JSON/CSV
+    \nПример:
+        - GET /api/general?login=john | Если не указать формат то выдаст JSON
+        - GET /api/general?login=natalya&format=csv | С указанием формата JSON/CSV
     """
     data = get_general_for_user(login)
+
+    if format.lower() == "csv":
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["date", "logins", "logouts", "blog_actions"])
+        for row in data:
+            writer.writerow([
+                row["date"],
+                row["logins"],
+                row["logouts"],
+                row["blog_actions"],
+            ])
+        csv_content = output.getvalue()
+        output.close()
+
+        response = StreamingResponse(
+            iter([csv_content]),
+            media_type="text/csv"
+        )
+        response.headers["Content-Disposition"] = "attachment; filename=general.csv"
+        return response
+
     return {
         "status": "ok",
         "data": data
     }
+


### PR DESCRIPTION
### Что сделано:
- Реализован возврат данных в формате CSV для endpoints `/api/comments` и `/api/general`.
- Добавлен параметр запроса `format=csv`.

### Как проверить:
- GET /api/comments?login=vadim&format=csv  --> должен возвращать CSV-файл.
- GET /api/general?login=andrey&format=csv  --> возвращает CSV-файл для общего дата-сета.

### На что обратить внимание:
- Добавлен header Content-Disposition, чтобы  **Clients** могли скачать CSV-файл сразу
